### PR TITLE
Feature-Zombie#1

### DIFF
--- a/Team Project 3D/Assets/Prefab/Enemy.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca91e2f16f7786a4b9686abb99849810
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie1.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie1.prefab
@@ -75,11 +75,43 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.3, y: 0.3, z: 0.3}
   m_Center: {x: 0.11, y: 0, z: 0}
+--- !u!114 &4068809597451226063
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6193004060720491310}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91122c4153567cd4d8bd459d66119afe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 10
+--- !u!4 &6249682425993752931 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+  m_PrefabInstance: {fileID: 5850717359377389192}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &6769057168536349657 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
   m_PrefabInstance: {fileID: 5850717359377389192}
   m_PrefabAsset: {fileID: 0}
+--- !u!136 &187668224
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6769057168536349657}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2.3
+  m_Direction: 1
+  m_Center: {x: 0, y: 1, z: 0}
 --- !u!95 &6662285583212708808
 Animator:
   serializedVersion: 5
@@ -101,17 +133,24 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!136 &187668224
-CapsuleCollider:
+--- !u!114 &4872258759770827044
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6769057168536349657}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  m_Radius: 0.35
-  m_Height: 2.3
-  m_Direction: 1
-  m_Center: {x: 0, y: 1, z: 0}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe3761f73edffe3429b740b1352b8f03, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 6249682425993752931}
+  hitbox: {fileID: 6193004060720491310}
+  detectionRange: 15
+  attackRange: 1.5
+  moveSpeed: 3
+  rotationSpeed: 10
+  attackCooldown: 2
+  frenzyDetectionRange: 30
+  frenzyMoveSpeed: 7

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie1.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie1.prefab
@@ -1,0 +1,117 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5850717359377389192
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.805527
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29278064
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.8802218
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+      propertyPath: m_Name
+      value: Zombie1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+--- !u!1 &6193004060720491310 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -8881076401840751194, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+  m_PrefabInstance: {fileID: 5850717359377389192}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &512520835
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6193004060720491310}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.3, y: 0.3, z: 0.3}
+  m_Center: {x: 0.11, y: 0, z: 0}
+--- !u!1 &6769057168536349657 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: bfe752739efd1e74bb5d0e2aa40a98b7, type: 3}
+  m_PrefabInstance: {fileID: 5850717359377389192}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &6662285583212708808
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6769057168536349657}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 5f4b3482f1d69b34bafda28c81934d78, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!136 &187668224
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6769057168536349657}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2.3
+  m_Direction: 1
+  m_Center: {x: 0, y: 1, z: 0}

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie1.prefab.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2eca2d371e128a5489f88f80f570c150
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie2.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie2.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2996962451838504247
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 23.535793
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29278064
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.9183292
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+      propertyPath: m_Name
+      value: Zombie2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+--- !u!1 &2690391331134091366 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+  m_PrefabInstance: {fileID: 2996962451838504247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &359040722288770251
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2690391331134091366}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 871dbb60e6fbd1d4ca112997ba49e0e2, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie2.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie2.prefab
@@ -62,6 +62,20 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
   m_PrefabInstance: {fileID: 2996962451838504247}
   m_PrefabAsset: {fileID: 0}
+--- !u!136 &8880820384588035537
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2690391331134091366}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2.3
+  m_Direction: 1
+  m_Center: {x: 0, y: 1, z: 0}
 --- !u!95 &359040722288770251
 Animator:
   serializedVersion: 5
@@ -83,3 +97,21 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &5869765380666058815 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -512634123677276920, guid: e36c08199eb17e640bfe2a22767ce5f9, type: 3}
+  m_PrefabInstance: {fileID: 2996962451838504247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &6080856840527633248
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5869765380666058815}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.33, y: 0.16, z: 0.3}
+  m_Center: {x: 0.03, y: 0.02, z: -0.37}

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie2.prefab.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9b90f49bc71c1454cbb0c62918c057a3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie3.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie3.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8482018064393609833
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.737165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29278064
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.9330137
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+      propertyPath: m_Name
+      value: Zombie3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+--- !u!1 &8752543207271538488 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+  m_PrefabInstance: {fileID: 8482018064393609833}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &616177807196251343
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8752543207271538488}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 03e6a2b481e12674586e29e374a1c1a5, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie3.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie3.prefab
@@ -57,6 +57,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+--- !u!1 &960655981167527777 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -512634123677276920, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
+  m_PrefabInstance: {fileID: 8482018064393609833}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &3828996991889056114
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 960655981167527777}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.14, y: 0.2, z: 0.33}
+  m_Center: {x: 0.12, y: 0, z: -0.4}
 --- !u!1 &8752543207271538488 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: cfd9df7cd30abf14ea56a7c8d7f12e18, type: 3}
@@ -83,3 +101,17 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!136 &7514506138573507717
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8752543207271538488}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2.3
+  m_Direction: 1
+  m_Center: {x: 0, y: 1, z: 0}

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie3.prefab.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie3.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d4aad37b31274674eb1c008bd712c81a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie4.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie4.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &9068596737914728287
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.952911
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29278052
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.792509
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+      propertyPath: m_Name
+      value: Zombie4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+--- !u!1 &8150188757826490894 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+  m_PrefabInstance: {fileID: 9068596737914728287}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &2284021697587480608
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8150188757826490894}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 08ee3b386b135174eb2b004190a0f837, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie4.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie4.prefab
@@ -57,6 +57,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+--- !u!1 &3078140105497287934 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -2923433530071387231, guid: da3eaf1390679d5418048999ff048e38, type: 3}
+  m_PrefabInstance: {fileID: 9068596737914728287}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &2345376034886914745
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3078140105497287934}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.3, y: 0.3, z: 0.3}
+  m_Center: {x: -0.1, y: 0, z: 0}
 --- !u!1 &8150188757826490894 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: da3eaf1390679d5418048999ff048e38, type: 3}
@@ -83,3 +101,17 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!136 &4268898567601610623
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8150188757826490894}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.85, z: 0}

--- a/Team Project 3D/Assets/Prefab/Enemy/Zombie4.prefab.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy/Zombie4.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a5f3a1d3cbc796a4d95adf8003f2ccdf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5311415606664512612
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 25.927664
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29278076
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.781424
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_Name
+      value: ZombieArmy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+--- !u!1 &5004793910572710197 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+  m_PrefabInstance: {fileID: 5311415606664512612}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &4895907120313942373
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5004793910572710197}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: cd6aa89307c853545836065b556c25c7, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy.prefab
@@ -57,6 +57,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+--- !u!1 &3555365000267473260 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -512634123677276920, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+  m_PrefabInstance: {fileID: 5311415606664512612}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &5760996801726572603
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3555365000267473260}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.8, y: 0.23, z: 0.39999998}
+  m_Center: {x: 0.31, y: 0.004, z: -0.05}
 --- !u!1 &5004793910572710197 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
@@ -83,3 +101,17 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!136 &2055512361612670874
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5004793910572710197}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2.3
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.95, z: 0}

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy.prefab.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76d17ef841300874799641118d217215
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy1.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy1.prefab
@@ -1,0 +1,156 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5311415606664512612
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 25.927664
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29278076
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.781424
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+      propertyPath: m_Name
+      value: ZombieArmy1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+--- !u!1 &3555365000267473260 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -512634123677276920, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+  m_PrefabInstance: {fileID: 5311415606664512612}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &5760996801726572603
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3555365000267473260}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.8, y: 0.23, z: 0.39999998}
+  m_Center: {x: 0.31, y: 0.004, z: -0.05}
+--- !u!114 &5191393178137338172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3555365000267473260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91122c4153567cd4d8bd459d66119afe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 15
+--- !u!1 &5004793910572710197 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+  m_PrefabInstance: {fileID: 5311415606664512612}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &2055512361612670874
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5004793910572710197}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2.3
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.95, z: 0}
+--- !u!95 &4895907120313942373
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5004793910572710197}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: cd6aa89307c853545836065b556c25c7, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &8867141417065626907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5004793910572710197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe3761f73edffe3429b740b1352b8f03, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 5638305690730177423}
+  hitbox: {fileID: 3555365000267473260}
+  detectionRange: 15
+  attackRange: 1.5
+  moveSpeed: 4
+  rotationSpeed: 10
+  attackCooldown: 2
+  frenzyDetectionRange: 30
+  frenzyMoveSpeed: 7
+--- !u!4 &5638305690730177423 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: de1c4a771ceabf245b517c63723b784e, type: 3}
+  m_PrefabInstance: {fileID: 5311415606664512612}
+  m_PrefabAsset: {fileID: 0}

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy1.prefab.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieArmy1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76d17ef841300874799641118d217215
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist.prefab
@@ -83,3 +83,35 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!136 &2115935928001892204
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118561314616132601}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2.3
+  m_Direction: 1
+  m_Center: {x: 0, y: 1, z: 0}
+--- !u!1 &7585482755490814880 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -512634123677276920, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+  m_PrefabInstance: {fileID: 1272211487046860456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &5324191785512662021
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7585482755490814880}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 0.34, z: 0.3}
+  m_Center: {x: 0.16, y: 0.025, z: -0.15}

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1272211487046860456
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.670807
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29278064
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.19553
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_Name
+      value: ZombieScientist
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+--- !u!1 &2118561314616132601 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+  m_PrefabInstance: {fileID: 1272211487046860456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &25209831069841613
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118561314616132601}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: ef64ae65b8910aa4ea547db07c45def8, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist.prefab.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c49d4548db5d6b4ba23a81fde2f7cf5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist1.prefab
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist1.prefab
@@ -1,0 +1,156 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1272211487046860456
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.670807
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29278064
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.19553
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+      propertyPath: m_Name
+      value: ZombieScientist1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+--- !u!4 &1598061974416267587 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+  m_PrefabInstance: {fileID: 1272211487046860456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2118561314616132601 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+  m_PrefabInstance: {fileID: 1272211487046860456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &2115935928001892204
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118561314616132601}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.35
+  m_Height: 2.3
+  m_Direction: 1
+  m_Center: {x: 0, y: 1, z: 0}
+--- !u!95 &25209831069841613
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118561314616132601}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: ef64ae65b8910aa4ea547db07c45def8, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &1562626048957974857
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118561314616132601}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe3761f73edffe3429b740b1352b8f03, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1598061974416267587}
+  hitbox: {fileID: 7585482755490814880}
+  detectionRange: 15
+  attackRange: 1.5
+  moveSpeed: 3
+  rotationSpeed: 10
+  attackCooldown: 2
+  frenzyDetectionRange: 30
+  frenzyMoveSpeed: 7
+--- !u!1 &7585482755490814880 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -512634123677276920, guid: 87fa71148c4167245a284d9a388e7ab6, type: 3}
+  m_PrefabInstance: {fileID: 1272211487046860456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &5324191785512662021
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7585482755490814880}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 0.34, z: 0.3}
+  m_Center: {x: 0.16, y: 0.025, z: -0.15}
+--- !u!114 &360307588091942500
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7585482755490814880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91122c4153567cd4d8bd459d66119afe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 10

--- a/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist1.prefab.meta
+++ b/Team Project 3D/Assets/Prefab/Enemy/ZombieScientist1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c49d4548db5d6b4ba23a81fde2f7cf5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Scenes/Sample Scene Sujin.unity.meta
+++ b/Team Project 3D/Assets/Scenes/Sample Scene Sujin.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9c74548dc46666342b9401533f7e9370
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Project 3D/Assets/Scripts/Enemy.cs
+++ b/Team Project 3D/Assets/Scripts/Enemy.cs
@@ -16,7 +16,7 @@ public class Enemy : MonoBehaviour
     [Tooltip("이 거리 안으로 들어오면 이동을 멈추고 공격을 시작합니다.")]
     public float attackRange = 1.5f;
     [Tooltip("적의 이동 속도입니다.")]
-    public float moveSpeed = 3.5f;
+    public float moveSpeed; // 좀비마다 속도를 다르게 하기 위해 지정하지 않음
     [Tooltip("적이 플레이어를 향해 회전하는 속도입니다.")]
     public float rotationSpeed = 10f;
 

--- a/Team Project 3D/Assets/Scripts/EnemyHitbox.cs
+++ b/Team Project 3D/Assets/Scripts/EnemyHitbox.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class EnemyHitbox : MonoBehaviour
 {
-    public int damage = 10;
+    public int damage; // 좀비마다 주는 데미지를 다르게 하기 위해 지정하지 않음
 
     // Trigger가 다른 Collider(플레이어)와 충돌했을 때 호출
     private void OnTriggerEnter(Collider other)

--- a/Team Project 3D/Assets/ThirdParty/Lowpoly Zombies/AnimationControllers/AC_Zombie.controller
+++ b/Team Project 3D/Assets/ThirdParty/Lowpoly Zombies/AnimationControllers/AC_Zombie.controller
@@ -79,7 +79,7 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 9144942549827865413}
+  m_DefaultState: {fileID: -1462399824914634334}
 --- !u!1101 &-1766082941020441296
 AnimatorStateTransition:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
## 좀비 프리팹
- 에셋에서 필요한 좀비 모델을 프리팹에 추가 (Zombie1, Zombie2, Zombie3, Zombie4, ZombieArmy1, ZombieScientist1)
- 각 프리팹에 본체 캡슐 콜라이더, 공격을 위한 박스 콜라이더 추가
- 일반 좀비(Zombie1), 군인 좀비(ZombieArmy1), 관리자좀비(ZombieScientist1)에 스크립트 추가
- 각 좀비 별로 이동속도와 데미지 값을 다르게 설정

## 관련 이슈
#14 

## 다음 작업
각 좀비 모델의 애니메이터 작업(#15 )